### PR TITLE
Add interrupted states

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,8 @@ inputs:
   failureStates:
     description: "semi-colon separated list of states to consider failure, default 'error;failure'"
     required: false
+  interruptedStates:
+    description: "semi-colon separated list of states to consider a 'neutral exit' - neither a failure or success, default: ''"
   ref:
     description: 'ref'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,9 @@ outputs:
     description: 'number of failing checks'
   failedCheckNames:
     description: "semi-colon separated list of failed checks"
-  failedCheckStates:
+  interruptedCheckNames:
+    description: "semi-colon separated list of interrupted checks"
+  checkStates:
     description: "semi-colon separated list of check results, on timeout will be state or 'not_present'"
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -308,6 +308,7 @@ exports.INPUT_NAMES = {
     pollInterval: "pollInterval",
     completeStates: "completeStates",
     failureStates: "failureStates",
+    interruptedStates: "interruptedStates",
     ref: "ref",
     owner: "owner",
     repository: "repository"
@@ -687,7 +688,8 @@ exports.DEFAULTS = {
     notPresentTimeout: 300,
     pollInterval: 10,
     completeStates: ['success'],
-    failureStates: ['error', 'failure']
+    failureStates: ['error', 'failure'],
+    interruptedStates: []
 };
 function importInputs(testActionsCore = null) {
     var _a;
@@ -700,6 +702,7 @@ function importInputs(testActionsCore = null) {
         pollInterval: getNumber(core, constants_1.INPUT_NAMES.pollInterval, exports.DEFAULTS.pollInterval),
         completeStates: getStringArrayOrDefault(core, constants_1.INPUT_NAMES.completeStates, exports.DEFAULTS.completeStates),
         failureStates: getStringArrayOrDefault(core, constants_1.INPUT_NAMES.failureStates, exports.DEFAULTS.failureStates),
+        interruptedStates: getStringArrayOrDefault(core, constants_1.INPUT_NAMES.interruptedStates, exports.DEFAULTS.interruptedStates),
         ref: getString(core, constants_1.INPUT_NAMES.ref),
         owner: getString(core, constants_1.INPUT_NAMES.owner),
         repository: getString(core, constants_1.INPUT_NAMES.repository)

--- a/dist/index.js
+++ b/dist/index.js
@@ -317,10 +317,9 @@ exports.OUTPUT_NAMES = {
     result: "result",
     numberOfFailedChecks: "numberOfFailedChecks",
     failedCheckNames: "failedCheckNames",
-    failedCheckStates: "failedCheckStates",
     numberOfInterruptedChecks: "numberOfInterruptedChecks",
     interruptedCheckNames: "interruptedCheckNames",
-    interruptedCheckStates: "interruptedCheckStates"
+    checkStates: "checkStates"
 };
 
 
@@ -6685,32 +6684,32 @@ class AwaitRunner {
             let runResult = yield this.runLoop();
             let runOutput = {
                 failedCheckNames: [],
-                failedCheckStates: [],
                 interruptedCheckNames: [],
-                interruptedCheckStates: []
+                checkStates: []
             };
             if (runResult != RunResult_1.RunResult.success) {
                 this.getRunOutput(runOutput, runResult);
             }
             this.core.setOutput(constants_1.OUTPUT_NAMES.result, runResult);
+            this.core.setOutput(constants_1.OUTPUT_NAMES.checkStates, runOutput.checkStates.join(';'));
             this.core.setOutput(constants_1.OUTPUT_NAMES.numberOfFailedChecks, runOutput.failedCheckNames.length);
-            this.core.setOutput(constants_1.OUTPUT_NAMES.failedCheckStates, runOutput.failedCheckStates.join(';'));
+            this.core.setOutput(constants_1.OUTPUT_NAMES.numberOfInterruptedChecks, runOutput.interruptedCheckNames.length);
             this.core.setOutput(constants_1.OUTPUT_NAMES.failedCheckNames, runOutput.failedCheckNames.join(';'));
+            this.core.setOutput(constants_1.OUTPUT_NAMES.interruptedCheckNames, runOutput.interruptedCheckNames.join(';'));
         });
     }
     getRunOutput(output, runResult) {
         this.inputs.contexts.forEach(element => {
             let curStatus = this.currentStatuses[element];
+            output.checkStates.push(curStatus);
             if (runResult == RunResult_1.RunResult.failure) {
                 if (!this.inputs.completeStates.includes(curStatus) || curStatus == constants_1.NOT_PRESENT) {
                     output.failedCheckNames.push(element);
-                    output.failedCheckStates.push(curStatus);
                 }
             }
             if (runResult == RunResult_1.RunResult.interrupted) {
                 if (!this.inputs.completeStates.includes(curStatus) || curStatus == constants_1.NOT_PRESENT) {
                     output.interruptedCheckNames.push(element);
-                    output.interruptedCheckStates.push(curStatus);
                 }
             }
         });

--- a/src/AwaitRunner.ts
+++ b/src/AwaitRunner.ts
@@ -42,9 +42,8 @@ export class AwaitRunner {
 
         let runOutput: RunOutput = {
             failedCheckNames: [],
-            failedCheckStates: [],
             interruptedCheckNames: [],
-            interruptedCheckStates: []
+            checkStates: []
         }
 
         if (runResult != RunResult.success) {
@@ -52,24 +51,25 @@ export class AwaitRunner {
         }
 
         this.core.setOutput(OUTPUT_NAMES.result, runResult);
+        this.core.setOutput(OUTPUT_NAMES.checkStates, runOutput.checkStates.join(';'));
         this.core.setOutput(OUTPUT_NAMES.numberOfFailedChecks, runOutput.failedCheckNames.length);
-        this.core.setOutput(OUTPUT_NAMES.failedCheckStates, runOutput.failedCheckStates.join(';'));
+        this.core.setOutput(OUTPUT_NAMES.numberOfInterruptedChecks, runOutput.interruptedCheckNames.length);
         this.core.setOutput(OUTPUT_NAMES.failedCheckNames, runOutput.failedCheckNames.join(';'));
+        this.core.setOutput(OUTPUT_NAMES.interruptedCheckNames, runOutput.interruptedCheckNames.join(';'));
     }
 
     private getRunOutput(output:RunOutput, runResult:RunResult) {
         this.inputs.contexts.forEach(element => {
             let curStatus = this.currentStatuses[element]
+            output.checkStates.push(curStatus);
             if (runResult == RunResult.failure){
               if (!this.inputs.completeStates.includes(curStatus) || curStatus == NOT_PRESENT) {
                   output.failedCheckNames.push(element);
-                  output.failedCheckStates.push(curStatus);
               }
             }
             if (runResult == RunResult.interrupted){
               if (!this.inputs.completeStates.includes(curStatus) || curStatus == NOT_PRESENT) {
                   output.interruptedCheckNames.push(element);
-                  output.interruptedCheckStates.push(curStatus);
               }
             }
         });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,8 +18,7 @@ export const OUTPUT_NAMES = {
     result: "result",
     numberOfFailedChecks: "numberOfFailedChecks",
     failedCheckNames: "failedCheckNames",
-    failedCheckStates: "failedCheckStates",
     numberOfInterruptedChecks: "numberOfInterruptedChecks",
     interruptedCheckNames: "interruptedCheckNames",
-    interruptedCheckStates: "interruptedCheckStates"
+    checkStates: "checkStates"
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const INPUT_NAMES = {
     pollInterval: "pollInterval",
     completeStates: "completeStates",
     failureStates: "failureStates",
+    interruptedStates: "interruptedStates",
     ref: "ref",
     owner: "owner",
     repository: "repository"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,5 +18,8 @@ export const OUTPUT_NAMES = {
     result: "result",
     numberOfFailedChecks: "numberOfFailedChecks",
     failedCheckNames: "failedCheckNames",
-    failedCheckStates: "failedCheckStates"
+    failedCheckStates: "failedCheckStates",
+    numberOfInterruptedChecks: "numberOfInterruptedChecks",
+    interruptedCheckNames: "interruptedCheckNames",
+    interruptedCheckStates: "interruptedCheckStates"
 }

--- a/src/enums/RunResult.ts
+++ b/src/enums/RunResult.ts
@@ -1,5 +1,6 @@
 export enum RunResult{ 
     success = "success",
     failure = "failure",
-    timeout = "timeout"
+    timeout = "timeout",
+    interrupted = "interrupted"
 }

--- a/src/fn/importInputs.ts
+++ b/src/fn/importInputs.ts
@@ -10,7 +10,8 @@ export const DEFAULTS = {
     notPresentTimeout: 300,
     pollInterval: 10,
     completeStates: ['success'],
-    failureStates: ['error', 'failure']
+    failureStates: ['error', 'failure'],
+    interruptedStates: []
 }
 
 export default function importInputs(testActionsCore: any | null = null): Inputs {
@@ -25,6 +26,7 @@ export default function importInputs(testActionsCore: any | null = null): Inputs
         pollInterval: getNumber(core, INPUT_NAMES.pollInterval, DEFAULTS.pollInterval),
         completeStates: getStringArrayOrDefault(core, INPUT_NAMES.completeStates, DEFAULTS.completeStates),
         failureStates: getStringArrayOrDefault(core, INPUT_NAMES.failureStates, DEFAULTS.failureStates),
+        interruptedStates: getStringArrayOrDefault(core, INPUT_NAMES.interruptedStates, DEFAULTS.interruptedStates),
         ref: getString(core, INPUT_NAMES.ref),
         owner: getString(core, INPUT_NAMES.owner),
         repository: getString(core, INPUT_NAMES.repository)

--- a/src/fn/statusFunctions.ts
+++ b/src/fn/statusFunctions.ts
@@ -11,6 +11,14 @@ export function statusesHasFailure(failureStates: string[], currentStatuses: Che
     return false;
 }
 
+export function statusesHasInterrupted(interruptedStates: string[], currentStatuses: CheckStatus): boolean {
+    let props = Object.getOwnPropertyNames(currentStatuses);
+    if (props.find(propName => interruptedStates.includes(currentStatuses[propName]))) {
+        return true;
+    }
+    return false;
+}
+
 export function statusesAllComplete(completeStates: string[], currentStatuses: CheckStatus) {
     let props = Object.getOwnPropertyNames(currentStatuses);
     if (props.find(propName => !completeStates.includes(currentStatuses[propName]))) {

--- a/src/interfaces/Inputs.ts
+++ b/src/interfaces/Inputs.ts
@@ -6,7 +6,8 @@ export interface Inputs {
     pollInterval: number,
     completeStates: string[],
     failureStates: string[],
-    ref: string
+    interruptedStates: string[],
+    ref: string,
     owner: string,
     repository: string
 }

--- a/src/interfaces/RunOutput.ts
+++ b/src/interfaces/RunOutput.ts
@@ -1,6 +1,5 @@
 interface RunOutput {
     failedCheckNames: string[],
-    failedCheckStates: string[],
     interruptedCheckNames: string[],
-    interruptedCheckStates: string[]
+    checkStates: string[]
 }

--- a/src/interfaces/RunOutput.ts
+++ b/src/interfaces/RunOutput.ts
@@ -1,4 +1,6 @@
 interface RunOutput {
     failedCheckNames: string[],
-    failedCheckStates: string[]
+    failedCheckStates: string[],
+    interruptedCheckNames: string[],
+    interruptedCheckStates: string[]
 }


### PR DESCRIPTION
Sometimes, you want to have a third (I guess fourth including timeout) behaviour if, for instance, the status(es) you are monitoring error. An example of this is if a job on Gitlab is cancelled, it will report 'error' on Github (since Github statuses for some reason only support 4 status types). This adds an 'interrupted' output, which is probably naively named to handle this specific circumstance.

We could just remove error from FailedStates, but that would cause the job to run until timeout. For long-running jobs this is a big waste of Actions minutes.